### PR TITLE
Add exception for 429 Too Many Requests errors

### DIFF
--- a/lib/createsend/createsend.rb
+++ b/lib/createsend/createsend.rb
@@ -30,6 +30,8 @@ module CreateSend
   class Unauthorized < CreateSendError; end
   # Raised for HTTP response code of 404
   class NotFound < ClientError; end
+  # Raised for HTTP response code of 429
+  class TooManyRequests < ClientError; end
 
   # Raised for HTTP response code of 401, specifically when an OAuth token
   # in invalid (Code: 120, Message: 'Invalid OAuth Token')
@@ -279,6 +281,8 @@ module CreateSend
         end
       when 404
         raise NotFound.new
+      when 429
+        raise TooManyRequests.new
       when 400...500
         raise ClientError.new
       when 500...600

--- a/test/createsend_test.rb
+++ b/test/createsend_test.rb
@@ -278,11 +278,12 @@ class CreateSendTest < Test::Unit::TestCase
         @template = CreateSend::Template.new @auth, '98y2e98y289dh89h938389'
       end
 
-      { ["400", "Bad Request"]  => CreateSend::BadRequest,
-        ["401", "Unauthorized"] => CreateSend::Unauthorized,
-        ["404", "Not Found"]    => CreateSend::NotFound,
-        ["418", "I'm a teapot"] => CreateSend::ClientError,
-        ["500", "Server Error"] => CreateSend::ServerError
+      { ["400", "Bad Request"]       => CreateSend::BadRequest,
+        ["401", "Unauthorized"]      => CreateSend::Unauthorized,
+        ["404", "Not Found"]         => CreateSend::NotFound,
+        ["418", "I'm a teapot"]      => CreateSend::ClientError,
+        ["429", "Too many requests"] => CreateSend::TooManyRequests,
+        ["500", "Server Error"]      => CreateSend::ServerError
       }.each do |status, exception|
         context "#{status.first}, a get" do
           should "raise a #{exception.name} error" do


### PR DESCRIPTION
From https://github.com/campaignmonitor/createsend-ruby/pull/67

> When rate limits are hit a generic `CreateSend::ClientError` is raised with no explanatory details, which makes implementing a backoff / retry mechanism difficult. If the same request is made manually, we may see a response like:
> 
> ```
> {
>   "Code" => 429,
>   "Message" => "Subscriber was added too many times too quickly, try again later."
> }
> ```
> 
> Which allow us to differentiate between rate limiting errors and other client errors. This adds a new `CreateSend::TooManyRequests` exception to be raised when the API responds with such a 429 so we can do so in code.
> 
> `CreateSend::TooManyRequests` inherits from `ClientError`, so any current code that rescues `ClientError` should be unaffected.
> 